### PR TITLE
using python3-alpine as docker base image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,14 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag floccuswebdav:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:latest
+FROM python:3-alpine
 
 EXPOSE 8081
 
-RUN apk --no-cache add py-lxml py-pip
-
-RUN pip install wsgidav cheroot lxml
+RUN apk add --no-cache --virtual .build-deps gcc libxslt-dev musl-dev py3-lxml py3-pip \
+    && pip3 install wsgidav cheroot lxml \
+    && apk del .build-deps gcc musl-dev
 
 RUN mkdir -p /var/floccuswebdav
 RUN mkdir -p /var/floccuswebdav/bookmarks

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 cd /var/floccuswebdav/
 sed -i 's/usertochange/\'"$USER"'/g ; s/passtochange/\'"$PASS"'/g' floccus.yaml
-/usr/bin/wsgidav -c floccus.yaml
+wsgidav -c floccus.yaml


### PR DESCRIPTION
Hi, 

at the moment i got a error by execute the docker [build](https://github.com/nolte/Floccus-WebDavDocker/runs/462228515#step:3:157)

```
    unable to execute 'gcc': No such file or directory
```

This Pull Request change the used base image to [python:3-alpine](https://hub.docker.com/_/python?tab=tags&page=1&name=3-alpine).
